### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.npm
           key: npm
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.cache/pip
           key: pip
@@ -48,17 +48,17 @@ jobs:
     needs: test
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3.2.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -72,7 +72,7 @@ jobs:
       PROJECT: blog
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v3.0

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v3.0

--- a/.github/workflows/find_broken_links.yaml
+++ b/.github/workflows/find_broken_links.yaml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.npm
           key: npm

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -15,7 +15,7 @@ jobs:
       COMMITTER_EMAIL: desecho@gmail.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1)** on 2022-10-13T12:19:17Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11)** on 2022-10-13T11:18:20Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.2.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.2.1)** on 2022-10-18T09:17:35Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0)** on 2022-10-12T07:04:14Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v3.2.0](https://github.com/docker/build-push-action/releases/tag/v3.2.0)** on 2022-10-12T07:10:45Z
