### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.8.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.npm
           key: npm
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cache/pip
           key: pip
@@ -48,17 +48,17 @@ jobs:
     needs: test
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v2.10.0
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v4.1.1
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -72,10 +72,10 @@ jobs:
       PROJECT: blog
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.6.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.6.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/find_broken_links.yaml
+++ b/.github/workflows/find_broken_links.yaml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.8.1
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.npm
           key: npm

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -15,7 +15,7 @@ jobs:
       COMMITTER_EMAIL: desecho@gmail.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.6.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.2.0](https://github.com/docker/login-action/releases/tag/v2.2.0)** on 2023-06-07T13:07:43Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.8.1](https://github.com/actions/setup-node/releases/tag/v3.8.1)** on 2023-08-17T13:14:07Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.1](https://github.com/actions/cache/releases/tag/v3.3.1)** on 2023-03-13T05:05:19Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.10.0)** on 2023-08-28T07:09:22Z
* **[azure/setup-kubectl](https://github.com/azure/setup-kubectl)** published a new release **[v3.2](https://github.com/Azure/setup-kubectl/releases/tag/v3.2)** on 2023-01-09T19:06:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.6.0](https://github.com/actions/checkout/releases/tag/v3.6.0)** on 2023-08-24T13:56:41Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.1.1](https://github.com/docker/build-push-action/releases/tag/v4.1.1)** on 2023-06-13T11:22:58Z
