### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: 15.x
           registry-url: https://registry.npmjs.org
@@ -48,17 +48,17 @@ jobs:
     needs: test
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Login to GitHub registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v6.18.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -72,10 +72,10 @@ jobs:
       PROJECT: blog
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.2.2
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v4.0.0
 
       - name: Configure kubectl
         run: |
@@ -85,7 +85,7 @@ jobs:
           KUBECONFIG: ${{ secrets.KUBECONFIG }} # Done as a variable because it doesn't work in place.
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.2.0
+        uses: digitalocean/action-doctl@v2.5.1
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.2.2
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v4.0.0
 
       - name: Configure kubectl
         run: |
@@ -22,7 +22,7 @@ jobs:
           KUBECONFIG: ${{ secrets.KUBECONFIG }} # Done as a variable because it doesn't work in place.
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.2.0
+        uses: digitalocean/action-doctl@v2.5.1
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 

--- a/.github/workflows/find_broken_links.yaml
+++ b/.github/workflows/find_broken_links.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -15,7 +15,7 @@ jobs:
       COMMITTER_EMAIL: desecho@gmail.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4.2.2
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)** on 2025-02-26T15:36:31Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)** on 2025-05-27T16:39:16Z
* **[digitalocean/action-doctl](https://github.com/digitalocean/action-doctl)** published a new release **[v2.5.1](https://github.com/digitalocean/action-doctl/releases/tag/v2.5.1)** on 2024-01-26T15:08:40Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.4.0](https://github.com/actions/setup-node/releases/tag/v4.4.0)** on 2025-04-14T02:55:06Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
* **[azure/setup-kubectl](https://github.com/azure/setup-kubectl)** published a new release **[v4.0.0](https://github.com/Azure/setup-kubectl/releases/tag/v4.0.0)** on 2024-02-07T18:11:50Z
